### PR TITLE
Fix long option validity checking

### DIFF
--- a/haur
+++ b/haur
@@ -30,6 +30,7 @@ for arg in "$@"; do
     "--remove") set -- "$@" "-r" ;;
     "--clear-cache") set -- "$@" "-c" ;;
     "--help")   set -- "$@" "-h" ;;
+    "--"*) echo "Invalid Option: ${arg}" ; exit 1 ;;
     *)        set -- "$@" "$arg"
   esac
 done


### PR DESCRIPTION
Before, the error handler would spit out an unintelligible mess. Now, it will neatly tell you which long option was invalid.