### PR TITLE
Remove alternative installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ cd haur
 makepkg -si
 ```
 
-Alternative install (not supported, use AUR instead):
-```bash
-git clone https://github.com/karx1/haur.git
-./install.sh
-```
-
 ## Usage
 
 Usage is pretty simple.


### PR DESCRIPTION
This removes the alternative installation instructions, because the installation helper has been deleted. However, you can still use "make install", but this will not be documented and will likely change in the future.