### PR TITLE
Suppress tput errors

### DIFF
--- a/haur
+++ b/haur
@@ -3,21 +3,21 @@
 if test -t 1; then
 
     # see if it supports colors...
-    ncolors=$(tput colors)
+    ncolors=$(tput colors 2>/dev/null)
 
     if test -n "$ncolors" && test $ncolors -ge 8; then
-        bold="$(tput bold)"
-        underline="$(tput smul)"
-        standout="$(tput smso)"
-        normal="$(tput sgr0)"
-        black="$(tput setaf 0)"
-        red="$(tput setaf 1)"
-        green="$(tput setaf 2)"
-        yellow="$(tput setaf 3)"
-        blue="$(tput setaf 4)"
-        magenta="$(tput setaf 5)"
-        cyan="$(tput setaf 6)"
-        white="$(tput setaf 7)"
+        bold="$(tput bold 2>/dev/null)"
+        underline="$(tput smul 2>/dev/null)"
+        standout="$(tput smso 2>/dev/null)"
+        normal="$(tput sgr0 2>/dev/null)"
+        black="$(tput setaf 0 2>/dev/null)"
+        red="$(tput setaf 1 2>/dev/null)"
+        green="$(tput setaf 2 2>/dev/null)"
+        yellow="$(tput setaf 3 2>/dev/null)"
+        blue="$(tput setaf 4 2>/dev/null)"
+        magenta="$(tput setaf 5 2>/dev/null)"
+        cyan="$(tput setaf 6 2>/dev/null)"
+        white="$(tput setaf 7 2>/dev/null)"
     fi
 fi
 


### PR DESCRIPTION
This will suppress errors if the terminal supports colors but tput is not found. This way, we can simply ignore colors if tput is not installed on the target system.